### PR TITLE
Ignore *.pyc files in ./resources folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+resources/**/*.pyc


### PR DESCRIPTION
After plugin has been executed lots of *.pyc files are created in ./resources. Wouldn't it be nice to ignore them? Or do you have other ignore policies?