### PR TITLE
Fix for losing tags when files are updated

### DIFF
--- a/resources/lib/MypicsDB.py
+++ b/resources/lib/MypicsDB.py
@@ -472,9 +472,6 @@ class MyPictureDB(object):
                         id_tagcontents=[row for row in self.cur.request("SELECT idTagContent FROM TagsInFiles WHERE idFile=?", (id_file,))]
                         self.cur.execute("Delete From TagsInFiles Where idFile=?", (id_file,))
                         
-                        for id_tagcontent in id_tagcontents:
-                            self.cur.execute("Delete From TagContents Where idTagContent= ?", (id_tagcontent[0],))
-
                         self.cur.execute( """Update Files set ftype=?, Thumb=?, ImageRating=?, ImageDateTime=?, Sha=? where idFile=?""", ( dictionnary["ftype"], dictionnary["Thumb"], dictionnary["Image Rating"], imagedatetime, sha, str(id_file) ) )
                         
                     except:

--- a/scanpath.py
+++ b/scanpath.py
@@ -147,6 +147,7 @@ class VFSScanner:
         # delete all entries with "sha is null"
         self.picsdeleted += self.mpdb.del_pics_wo_sha(self.scan_is_cancelled)
 
+        common.log("VFSScanner.dispatcher", common.getstring(30248)%(self.picsscanned,self.picsadded,self.picsdeleted,self.picsupdated), xbmc.LOGNOTICE)
         common.show_notification(common.getstring(30000), common.getstring(30248)%(self.picsscanned,self.picsadded,self.picsdeleted,self.picsupdated) )
         
 


### PR DESCRIPTION
The Delete From TagContents was incorrect to do in an update as tags could be present in other files. Defer the cleanup of TagContents to cleanup_keywords(). The problem is described in more detail here: http://forum.kodi.tv/showthread.php?tid=133905&pid=2398295#pid2398295

Also added the summary notification to the log file.
