### PR TITLE
INDEX idxTagsInFiles3 on table TagsInFiles must be UNIQUE

### DIFF
--- a/resources/lib/MypicsDB.py
+++ b/resources/lib/MypicsDB.py
@@ -103,7 +103,7 @@ class MyPictureDB(object):
                 pass
 
             try:
-                self.cur.execute("CREATE INDEX idxTagsInFiles3 ON TagsInFiles(idFile,idTagContent)")
+                self.cur.execute("CREATE UNIQUE INDEX idxTagsInFiles3 ON TagsInFiles(idFile,idTagContent)")
             except:
                 pass
                 


### PR DESCRIPTION
To avoid to have multiple entries with same content in table TagsInFiles, index idxTagsInFiles3 must be unique.

For existing DB :
```
ALTER TABLE `MyPicsDB`.`TagsInFiles` 
DROP INDEX `idxTagsInFiles3` ,
ADD UNIQUE INDEX `idxTagsInFiles3` (`idFile` ASC, `idTagContent` ASC);
```
